### PR TITLE
Allow research theme logos to size naturally

### DIFF
--- a/research.html
+++ b/research.html
@@ -31,19 +31,18 @@
     .grid{display:grid;grid-template-columns:repeat(12,1fr);gap:clamp(12px,2vw,20px)}
     .card{background:var(--panel);border:1px solid color-mix(in oklab, var(--text) 10%, transparent);border-radius:18px;padding:18px;box-shadow:var(--shadow)}
     .figure {
-  aspect-ratio: 16/9;
-  border-radius: 14px;
-  display: grid;
-  place-items: center;
-  background: none;
-  overflow: hidden;
-}
-.figure img {
-  max-width: 95%;
-  max-height: 95%;
-  object-fit: contain;
-  display: block;
-}
+      border-radius: 14px;
+      display: grid;
+      place-items: center;
+      background: none;
+      overflow: hidden;
+    }
+    .figure img {
+      width: 100%;
+      height: auto;
+      object-fit: contain;
+      display: block;
+    }
     .theme{grid-column:span 4;display:flex;flex-direction:column;gap:10px}
     .theme h3{margin:6px 0 2px}
     .summary{white-space:pre-wrap}


### PR DESCRIPTION
## Summary
- remove the fixed aspect ratio and max dimension limits from research theme figures
- let each research theme logo scale naturally by using full-width images that maintain aspect ratio

## Testing
- python3 -m http.server 8000 # manually verified research theme logos in browser

------
https://chatgpt.com/codex/tasks/task_e_68c97e52a93c83288b19976ec01356ff