### PR TITLE
Fix news feed loading

### DIFF
--- a/news.html
+++ b/news.html
@@ -172,7 +172,7 @@
 
       async function fetchRSS(url){
         // Use r.jina.ai as a CORS-friendly proxy that returns raw feed text
-        const proxied = 'https://r.jina.ai/http://' + url.replace(/^https?:\\/\\//,'').replaceAll('&','&');
+        const proxied = 'https://r.jina.ai/http://' + url.replace(/^https?:\/\//,'').replaceAll('&','&');
         const res = await fetch(proxied, { cache: 'no-cache' });
         if(!res.ok) throw new Error('HTTP '+res.status);
         const xml = await res.text();
@@ -221,7 +221,7 @@
           seen.add(key);
           const text = (it.title || '') + ' ' + (it.description || '');
           // Must mention Stephane Angers and have biomedical hint
-          const hasName = /stephane\\s+angers/i.test(text) || /stephane\\s+angers/i.test(it.link||'');
+          const hasName = /stephane\s+angers/i.test(text) || /stephane\s+angers/i.test(it.link||'');
           return hasName && includesBioKeywords(text + ' ' + it.link);
         });
 


### PR DESCRIPTION
## Summary
- fix the proxied feed URL regex so the script builds the proxy URL correctly
- correct the Stephane Angers regex so news items from the local JSON pass the filter

## Testing
- node - <<'NODE'
const fs = require('fs');
const KEYWORDS = [
  'wnt','frizzled','β-catenin','beta-catenin','cancer','regeneration','glioblastoma','signaling','donnelly','university of toronto','fgf','surrogate','agonist','endothelial','barrier'
];
const includesBioKeywords = text => {
  const t = (text || '').toLowerCase();
  return KEYWORDS.some(k => t.includes(k));
};
const items = JSON.parse(fs.readFileSync('assets/data/news.json','utf8'));
const seen = new Set();
const filtered = items.filter(it => {
  const key = (it.link || it.title).trim();
  if(!key || seen.has(key)) return false;
  seen.add(key);
  const text = (it.title || '') + ' ' + (it.description || '');
  const hasName = /stephane\s+angers/i.test(text) || /stephane\s+angers/i.test(it.link||'');
  return hasName && includesBioKeywords(text + ' ' + it.link);
});
console.log('filtered length:', filtered.length);
NODE

------
https://chatgpt.com/codex/tasks/task_e_68c9e378d2d483289e8efdf368a0bf3d