### PR TITLE
Allow curated news JSON to populate feed

### DIFF
--- a/news.html
+++ b/news.html
@@ -208,8 +208,11 @@
       try {
         statusEl.textContent = 'Loading news…';
         statusEl.title = '';
+        let usedLocalJSON = false;
         let items = await tryLocalJSON();
-        if(items.length === 0){
+        if(items.length > 0){
+          usedLocalJSON = true;
+        } else {
           items = await tryFeeds();
         }
 
@@ -220,6 +223,9 @@
           if(!key || seen.has(key)) return false;
           seen.add(key);
           const text = (it.title || '') + ' ' + (it.description || '');
+          if(usedLocalJSON){
+            return true;
+          }
           // Must mention Stephane Angers and have biomedical hint
           const hasName = /stephane\s+angers/i.test(text) || /stephane\s+angers/i.test(it.link||'');
           return hasName && includesBioKeywords(text + ' ' + it.link);


### PR DESCRIPTION
## Summary
- detect when the curated `assets/data/news.json` file is available
- skip aggressive biomedical keyword filtering for curated entries so the feed displays them
- keep existing filtering for remote RSS feeds

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68c9fcbe1fdc832892e67126c834dc50