### PR TITLE
Fix news previews to fetch article images

### DIFF
--- a/news.html
+++ b/news.html
@@ -167,8 +167,16 @@
 
       function toProxyURL(url){
         if(!url) return '';
-        const clean = String(url).replace(/^https?:\/\//,'');
-        return 'https://r.jina.ai/http://' + clean.replace(/&/g,'&');
+        try {
+          const normalized = new URL(url, document.baseURI);
+          if(normalized.protocol !== 'http:' && normalized.protocol !== 'https:'){
+            return '';
+          }
+          const target = normalized.protocol + '//' + normalized.host + normalized.pathname + normalized.search + normalized.hash;
+          return 'https://r.jina.ai/' + target;
+        } catch {
+          return '';
+        }
       }
       function proxyFetch(url, init){
         const proxied = toProxyURL(url);


### PR DESCRIPTION
## Summary
- preserve the original protocol when proxying article pages for preview scraping
- gracefully skip proxying unsupported URL schemes to avoid bad requests

## Testing
- not run (static site change)


------
https://chatgpt.com/codex/tasks/task_e_68ca0954c0b88328affdcde1907a4e52