### PR TITLE
Prioritize article preview images

### DIFF
--- a/news.html
+++ b/news.html
@@ -457,24 +457,28 @@
 
           const baseUrl = it.link || document.baseURI;
           const inlineImage = directImageFromItem(it);
-          const loadFromArticle = () => {
-            if(!it.link){
+          const showInlineFallback = (noLink = false) => {
+            if(noLink){
               showNoPreview(preview, 'No link available');
               return;
             }
+            if(inlineImage){
+              const ok = displayPreviewImage(preview, inlineImage, baseUrl, () => showNoPreview(preview));
+              if(!ok){
+                showNoPreview(preview);
+              }
+            } else {
+              showNoPreview(preview);
+            }
+          };
+          if(it.link){
             ensureThumbFallback(preview, 'Loading preview…');
             getPreviewImage(it.link).then(src => {
-              if(src && displayPreviewImage(preview, src, baseUrl)) return;
-              showNoPreview(preview);
+              if(src && displayPreviewImage(preview, src, it.link, showInlineFallback)) return;
+              showInlineFallback();
             });
-          };
-          if(inlineImage){
-            const success = displayPreviewImage(preview, inlineImage, baseUrl, loadFromArticle);
-            if(!success){
-              loadFromArticle();
-            }
           } else {
-            loadFromArticle();
+            showInlineFallback(true);
           }
         }
       } catch (err){


### PR DESCRIPTION
## Summary
- ensure the news preview fetches its image from the linked article before using feed-provided fallbacks
- keep a fallback path for feeds while showing a clearer message when no article link is available

## Testing
- not run (static site)

------
https://chatgpt.com/codex/tasks/task_e_68ca1b686f948328a71fc17804f8e871