### PR TITLE
Upgrade news thumbnail URLs to HTTPS to fix mixed-content blocking

### DIFF
--- a/news.html
+++ b/news.html
@@ -696,10 +696,22 @@
         return fallback;
       }
 
+      function secureImageUrl(url){
+        if(!url || /^data:/i.test(url)) return url || '';
+        try {
+          const parsed = new URL(url, document.baseURI);
+          if(parsed.protocol === 'http:') parsed.protocol = 'https:';
+          return parsed.href;
+        } catch {
+          return url;
+        }
+      }
+
       function displayPreviewImage(el, src, base, onError){
         if(!el) return false;
         const original = (src || '').trim();
-        const resolved = /^data:/i.test(original) ? original : resolveUrlMaybe(original, base || document.baseURI);
+        const resolvedRaw = /^data:/i.test(original) ? original : resolveUrlMaybe(original, base || document.baseURI);
+        const resolved = secureImageUrl(resolvedRaw);
         if(!resolved) return false;
         const sources = [];
         const seen = new Set();


### PR DESCRIPTION
### Motivation
- Story thumbnails were failing to load on HTTPS deployments due to mixed-content blocking from `http:` image URLs, so image URLs should be normalized before rendering.

### Description
- Add a `secureImageUrl` helper to `news.html` and use it in `displayPreviewImage` to upgrade `http:` image URLs to `https:` (while preserving `data:` URLs) before building preview sources.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fe277982188328b551d15188b55426)